### PR TITLE
Add reMarkable-kaitai

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ This function may not do what you are expecting. While it resets all user data, 
 
 - [lines-are-beautiful](https://github.com/ax3l/lines-are-beautiful) - C++ File API for the reMarkable tablet.
 - [lines-are-rusty](https://github.com/ax3l/lines-are-rusty) - Rust File API for the reMarkable tablet.
+- [reMarkable-kaitai](https://github.com/matomatical/reMarkable-kaitai) - [Kaitai Struct](https://kaitai.io/) format specification for the binary lines format.
 - [reMarkable-layers](https://github.com/bsdz/remarkable-layers) - Python API for reading & writing reMarkable Lines format. Supports very basic conversion of PDFs and SVGs to Lines format.
 - [rmrl](https://github.com/rschroll/rmrl) - The reMarkable Rendering Library for Python converts annotated documents to PDF files.
 


### PR DESCRIPTION
Add the following project to the Lines Format section:

- [reMarkable-kaitai](https://github.com/matomatical/reMarkable-kaitai) - [Kaitai Struct](https://kaitai.io/) format specification for the binary lines format.

Extended description: [Kaitai Struct](https://kaitai.io/) format specification for the binary lines format. Can be used to generate parser code in various languages. Based on the same reverse engineering results as lines-are-beautiful/lines-are-rusty.